### PR TITLE
Spyglass tool setup

### DIFF
--- a/mk/spyglass.mk
+++ b/mk/spyglass.mk
@@ -1,12 +1,28 @@
+#Load Synopsys Spyglass
+#module load synopsys/spyglass/2023.03
+
 include mk/common.mk
 SPYGLASS_WORK_DIR := spyglass
 default: lint
 
 .PHONY: lint
-lint: $(addprefix ${OUTDIR}/,$(addsuffix .spyglass_lint.txt,${TESTCASE_NAMES}))
+lint: $(addprefix ${OUTDIR}/,\
+	$(addsuffix .spyglass_lint.stdout,${TESTCASE_NAMES}))
+
 export TESTCASE = $^
 export TESTCASE_REPORT = $@
-${OUTDIR}/%.spyglass_lint.txt: testcases/%.sv
+
+# See Spyglass Tcl Shell Interface User Guide, Version U-2023.03
+# SpyGlass_TclShellInterface_UserGuide.pdf
+# pages 39, 40, 42
+#
+# For commands used in tcl script,
+# see pages 92, 93, 129, 169, 216, 889, 890, 316, 317, 108, 109 
+#
+# For argument enableSV12 used with the set_option command in tcl script,
+# see SpyGlass Explorer User Guide, Version U-2023.03
+# SpyGlass_Explorer_UserGuide.pdf page 852
+#
+${OUTDIR}/%.spyglass_lint.stdout: testcases/%.sv | ${OUTDIR}
 	mkdir -p ${SPYGLASS_WORK_DIR}
-	mkdir -p ${OUTDIR}
-	sg_shell < tcl/spyglass_batch_run.tcl
+	sg_shell < tcl/spyglass_batch_run.tcl ${REDIRECT}

--- a/mk/spyglass.mk
+++ b/mk/spyglass.mk
@@ -10,7 +10,6 @@ lint: $(addprefix ${OUTDIR}/,\
 	$(addsuffix .spyglass_lint.stdout,${TESTCASE_NAMES}))
 
 export TESTCASE = $^
-export TESTCASE_REPORT = $@
 
 # See Spyglass Tcl Shell Interface User Guide, Version U-2023.03
 # SpyGlass_TclShellInterface_UserGuide.pdf

--- a/tcl/spyglass_batch_run.tcl
+++ b/tcl/spyglass_batch_run.tcl
@@ -1,6 +1,5 @@
 global env
 set TESTNAME $env(TESTCASE)
-set TESTREPORT $env(TESTCASE_REPORT)
 new_project spyglass_lint -projectwdir spyglass -force
 set_option enableSV12 yes
 read_file ${TESTNAME}

--- a/tcl/spyglass_batch_run.tcl
+++ b/tcl/spyglass_batch_run.tcl
@@ -1,11 +1,10 @@
 global env
-set TEST_NAME $env(TESTCASE)
-set TEST_REPORT $env(TESTCASE_REPORT)
+set TESTNAME $env(TESTCASE)
+set TESTREPORT $env(TESTCASE_REPORT)
 new_project spyglass_lint -projectwdir spyglass -force
-set_option enableSV yes
-set_option sfcu yes
-read_file ${TEST_NAME}
-current_goal lint/lint_rtl -alltop
+set_option enableSV12 yes
+read_file ${TESTNAME}
+current_goal lint/lint_rtl_enhanced -top top
 run_goal
-capture ${TEST_REPORT} {write_report moresimple}
+write_report moresimple
 exit -force


### PR DESCRIPTION
1. Made changes as per #6.
2. Spyglass run_goal and write_report commands appear to write to stdout by default. Tried 'capture' TCL command with option stderr , and stdout.
3. Removed 'capture' TCL command to make use of ${REDIRECT}.