### PR TITLE
VC Formal setup

### DIFF
--- a/mk/vcformal.mk
+++ b/mk/vcformal.mk
@@ -1,14 +1,24 @@
+#Load Synopsys VC Formal
+#module load synopsys/vc-static/2022.06-sp2
+
 include mk/common.mk
 
 default: compile
 
 .PHONY: compile
 compile: $(addprefix ${OUTDIR}/,$(addsuffix \
-.vcformal_compile.log,${TESTCASE_NAMES}))
+.vcformal_compile.stdout,${TESTCASE_NAMES}))
 
 export TESTCASE = $^
-export TESTCASE_REPORT = $@
 
-${OUTDIR}/%.vcformal_compile.log: testcases/%.sv
-	mkdir -p ${OUTDIR}
-	-vcf -batch -out_dir vcformal -f tcl/vcformal_batch_run.tcl
+#See VC FormalUser Guide, Version T-2022.06-SP2
+#pages 34, 35, 36, 75, and 101.
+
+#See VC Static Platform Command Reference Guide, Version T-2022-06-SP2
+#pages 161, 867, and 963.
+
+#See VC Formal Quick Reference Guide, Version T-2022.06-SP2
+#pages 2 and 4.
+
+${OUTDIR}/%.vcformal_compile.stdout: testcases/%.sv | ${OUTDIR}
+	-vcf -batch -out_dir vcformal -f tcl/vcformal_batch_run.tcl ${REDIRECT}

--- a/tcl/vcformal_batch_run.tcl
+++ b/tcl/vcformal_batch_run.tcl
@@ -1,5 +1,6 @@
 global env
 set TEST_NAME $env(TESTCASE)
-set TEST_REPORT $env(TESTCASE_REPORT)
-read_file -format sverilog -top top ${TEST_NAME} >> ${TEST_REPORT}
+read_file -format sverilog -top top ${TEST_NAME}
+check_fv_setup
+report_fv_setup -list
 quit


### PR DESCRIPTION
1. Made changes as per #6.
2. Output files with extension .stderr have output message "No protocol specified".
  Attempted fixes(Did not work):
Introduced 'aip_load' command with, and without flag '-protocol' and protocol argument to specify AIP protocol.

3. Output messages in .stdout files are okay even with "No protocol specified" message in stderr files.